### PR TITLE
Added the key name to the error message when we can't encode

### DIFF
--- a/src/writer.coffee
+++ b/src/writer.coffee
@@ -16,7 +16,10 @@ class Writer
     return definition._write.apply @, [valueToWrite, parameter] if definition.hasOwnProperty '_write'
     _.each definition, (value) =>
       key = Object.keys(value)[0]
-      @write value[key], valueToWrite[key], parameter, valueToWrite
+      try
+        @write value[key], valueToWrite[key], parameter, valueToWrite
+      catch err
+        throw new Error "'#{key}': #{err.message}"
 
   write: (typeName, valueToWrite, parameter, result={}) ->
 


### PR DESCRIPTION
This adds the field name to the error message when an object can't be encoded.

Instead of an error message: `undefined has no property length`
show the error: `'message_string': undefined as no property length`

This makes it much easier to debug issues further up the stack.